### PR TITLE
Increase request body limit to 50 MB for media uploads

### DIFF
--- a/packages/agent-server-rust/src/router/mod.rs
+++ b/packages/agent-server-rust/src/router/mod.rs
@@ -6,6 +6,7 @@ mod sessions;
 mod status;
 
 use axum::{
+    extract::DefaultBodyLimit,
     http::Method,
     routing::{get, post},
     Router,
@@ -48,5 +49,6 @@ pub fn build_router() -> Router {
         .route("/api/ws/login", get(status::login_ws))
         // Events WebSocket
         .route("/api/ws/events", get(events::events_ws))
+        .layer(DefaultBodyLimit::max(50 * 1024 * 1024)) // 50 MB for media uploads
         .layer(cors)
 }


### PR DESCRIPTION
Axum's default 2 MB body limit caused 413 Payload Too Large errors
when sending images or files via POST /api/messages/send, since
base64 encoding inflates payloads by ~33%.

https://claude.ai/code/session_01AQ1KjTTXMnY2Mv4eeCUMfv