### PR TITLE
Set up packaging + release pipeline for CLI, OpenClaw extension, and multi-arch Docker

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -1,0 +1,11 @@
+# Changesets
+
+This repo uses Changesets for npm package versioning.
+
+Typical flow:
+
+1. `pnpm changeset`
+2. Commit the generated file in `.changeset/`
+3. `pnpm changeset:version`
+4. Commit version/changelog updates
+5. Tag and push `vX.Y.Z` to trigger release workflows

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
+  "changelog": "@changesets/cli/changelog",
+  "commit": false,
+  "fixed": [["@agent-wechat/cli", "@agent-wechat/wechat"]],
+  "linked": [],
+  "access": "public",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": []
+}

--- a/.changeset/olive-ladybugs-say.md
+++ b/.changeset/olive-ladybugs-say.md
@@ -1,0 +1,11 @@
+---
+"@agent-wechat/cli": minor
+"@agent-wechat/wechat": minor
+---
+
+Prepare npm + Docker release foundation:
+
+- publishable package metadata for CLI and OpenClaw extension
+- bundled CLI build for standalone npm install
+- OpenClaw extension package name/id alignment to remove id mismatch warnings
+- tag-based GitHub Actions release workflows (npm trusted publishing + multi-arch Docker)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cargo check
+        run: cargo check --manifest-path packages/agent-server-rust/Cargo.toml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,222 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: agent-wechat/agent-wechat
+  WECHAT_DEB_URL_AMD64: https://dldir1v6.qq.com/weixin/Universal/Linux/WeChatLinux_x86_64.deb
+  WECHAT_DEB_URL_ARM64: https://dldir1v6.qq.com/weixin/Universal/Linux/WeChatLinux_arm64.deb
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build artifacts
+        run: pnpm build
+
+      - name: Verify tag matches package versions
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          for pkg in packages/cli/package.json packages/openclaw-extension/package.json; do
+            VERSION="$(jq -r '.version' "$pkg")"
+            if [ "$VERSION" != "$TAG" ]; then
+              echo "Version mismatch: $pkg has $VERSION but tag is $TAG"
+              exit 1
+            fi
+          done
+
+      - name: Publish @agent-wechat/cli
+        working-directory: packages/cli
+        run: npm publish --access public --provenance
+
+      - name: Publish @agent-wechat/wechat
+        working-directory: packages/openclaw-extension
+        run: npm publish --access public --provenance
+
+  build-amd64:
+    runs-on: ubuntu-latest
+    needs:
+      - publish-npm
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image-digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare Docker build context
+        run: |
+          rm -rf docker/agent-server-rust
+          mkdir -p docker/agent-server-rust
+          cp packages/agent-server-rust/Cargo.toml docker/agent-server-rust/
+          if [ -f packages/agent-server-rust/Cargo.lock ]; then
+            cp packages/agent-server-rust/Cargo.lock docker/agent-server-rust/
+          fi
+          cp -r packages/agent-server-rust/src docker/agent-server-rust/
+          cp -r packages/agent-server-rust/migrations docker/agent-server-rust/
+
+      - name: Download WeChat package (amd64)
+        run: curl -fL "$WECHAT_DEB_URL_AMD64" -o docker/wechat.deb
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (amd64)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}},suffix=-amd64
+            type=semver,pattern={{major}}.{{minor}},suffix=-amd64
+            type=raw,value=latest-amd64
+
+      - name: Build and push amd64 image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: docker
+          file: docker/Dockerfile
+          platforms: linux/amd64
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-cache:amd64
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-cache:amd64,mode=max
+          provenance: false
+          push: true
+
+  build-arm64:
+    runs-on: ubuntu-latest
+    needs:
+      - publish-npm
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image-digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare Docker build context
+        run: |
+          rm -rf docker/agent-server-rust
+          mkdir -p docker/agent-server-rust
+          cp packages/agent-server-rust/Cargo.toml docker/agent-server-rust/
+          if [ -f packages/agent-server-rust/Cargo.lock ]; then
+            cp packages/agent-server-rust/Cargo.lock docker/agent-server-rust/
+          fi
+          cp -r packages/agent-server-rust/src docker/agent-server-rust/
+          cp -r packages/agent-server-rust/migrations docker/agent-server-rust/
+
+      - name: Download WeChat package (arm64)
+        run: curl -fL "$WECHAT_DEB_URL_ARM64" -o docker/wechat.deb
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (arm64)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}},suffix=-arm64
+            type=semver,pattern={{major}}.{{minor}},suffix=-arm64
+            type=raw,value=latest-arm64
+
+      - name: Build and push arm64 image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: docker
+          file: docker/Dockerfile
+          platforms: linux/arm64
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-cache:arm64
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-cache:arm64,mode=max
+          provenance: false
+          push: true
+
+  create-manifest:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    needs:
+      - build-amd64
+      - build-arm64
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for manifest
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Create and push multi-arch manifest
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            ${{ needs.build-amd64.outputs.image-digest }} \
+            ${{ needs.build-arm64.outputs.image-digest }}
+        env:
+          DOCKER_METADATA_OUTPUT_JSON: ${{ steps.meta.outputs.json }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 
 WeChat automation via deterministic FSM. Runs WeChat in a Docker container with UI automation.
 
+## Install (Published CLI)
+
+```bash
+npm i -g @agent-wechat/cli
+wx up
+```
+
+By default, `wx up` uses local images when available (`agent-wechat:arm64` / `agent-wechat:amd64`), then falls back to `ghcr.io/agent-wechat/agent-wechat:latest`.
+
+Override image selection with:
+
+- `wx up --image <image-ref>`
+- `AGENT_WECHAT_IMAGE`
+- `AGENT_WECHAT_IMAGE_REPO`
+- `AGENT_WECHAT_IMAGE_TAG`
+
 ## Requirements
 
 - Docker (via Colima on macOS, or Docker Desktop)
@@ -75,6 +91,17 @@ pnpm dev:deploy
 # Type check Rust code
 cd packages/agent-server-rust && cargo check
 ```
+
+## OpenClaw Extension
+
+Install the plugin with:
+
+```bash
+openclaw plugins install @agent-wechat/wechat
+openclaw plugins enable wechat
+```
+
+For release instructions, see `docs/release.md`.
 
 ## Ports
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@
 
 services:
   agent-wechat:
-    image: agent-wechat:arm64 # or agent-wechat:amd64
+    image: ghcr.io/agent-wechat/agent-wechat:latest
     container_name: agent-wechat
     security_opt:
       - seccomp=unconfined

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,50 @@
+# Release Process
+
+This repo releases three artifacts together on tag push:
+
+1. npm CLI package: `@agent-wechat/cli`
+2. npm OpenClaw extension: `@agent-wechat/wechat`
+3. Docker image: `ghcr.io/agent-wechat/agent-wechat`
+
+## Prepare A Release
+
+1. Add changelog entries:
+
+```bash
+pnpm changeset
+```
+
+2. Apply version bumps:
+
+```bash
+pnpm changeset:version
+```
+
+3. Commit the result.
+
+4. Create and push a semver tag that matches package versions:
+
+```bash
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+## What CI/CD Does On Tag
+
+- Publishes `@agent-wechat/cli` and `@agent-wechat/wechat` to npm with provenance.
+- Builds and pushes `amd64` and `arm64` images.
+- Publishes a multi-arch manifest tag.
+
+Docker tags:
+
+- `vX.Y.Z`
+- `vX.Y`
+- `latest`
+
+## Trusted Publishing
+
+Configure npm trusted publishers for both packages to this repo/workflow.
+
+No npm access token is required once trusted publishing is configured.
+
+If you need a different GHCR path, update `IMAGE_NAME` in `.github/workflows/release.yml`.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build": "turbo run build",
     "build:watch": "turbo watch build",
     "typecheck": "turbo run typecheck",
+    "changeset": "pnpm dlx @changesets/cli",
+    "changeset:version": "pnpm dlx @changesets/cli version",
     "build:image": "bash scripts/build-images-local.sh",
     "build:image:arm64": "bash scripts/build-images-local.sh --arch arm64",
     "build:image:amd64": "bash scripts/build-images-local.sh --arch amd64",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,33 @@
+# @agent-wechat/cli
+
+CLI for running and controlling the `agent-wechat` container.
+
+## Install
+
+```bash
+npm i -g @agent-wechat/cli
+```
+
+## Quick Start
+
+```bash
+wx up
+wx status
+wx auth login
+wx chats list
+wx down
+```
+
+## Image Selection
+
+`wx up` resolves images in this order:
+
+1. `--image <ref>` option
+2. `AGENT_WECHAT_IMAGE` env var
+3. Local arch image (`agent-wechat:arm64` or `agent-wechat:amd64`)
+4. Published image (`ghcr.io/agent-wechat/agent-wechat:latest`)
+
+Override default remote repo/tag with:
+
+- `AGENT_WECHAT_IMAGE_REPO`
+- `AGENT_WECHAT_IMAGE_TAG`

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,27 +1,34 @@
 {
-  "name": "@thisnick/agent-wechat-cli",
+  "name": "@agent-wechat/cli",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "bin": {
     "wx": "./dist/cli.js"
   },
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
+    "build": "esbuild src/cli.ts --bundle --platform=node --format=esm --target=node22 --outfile=dist/cli.js --banner:js='#!/usr/bin/env node' && node -e \"require('fs').chmodSync('dist/cli.js', 0o755)\"",
+    "dev": "esbuild src/cli.ts --bundle --platform=node --format=esm --target=node22 --outfile=dist/cli.js --banner:js='#!/usr/bin/env node' --watch",
+    "prepack": "npm run build",
     "start": "node dist/cli.js",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@thisnick/agent-wechat-shared": "workspace:*",
     "commander": "^14.0.3",
     "qrcode-terminal": "^0.12.0"
   },
   "devDependencies": {
+    "@thisnick/agent-wechat-shared": "workspace:*",
     "@types/node": "^22",
     "@types/qrcode-terminal": "^0.12.2",
+    "esbuild": "^0.25.0",
     "typescript": "^5.4.5"
   }
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { Command, Option } from "commander";
-import { WeChatClient, type WeChatClientOptions } from "@thisnick/agent-wechat-shared";
+import { WeChatClient } from "@thisnick/agent-wechat-shared";
 import { createSubscriptionClient, type SubscriptionClientOptions } from "./lib/client.js";
 import { spawn, execSync } from "child_process";
 import { randomBytes } from "crypto";
@@ -9,16 +9,13 @@ import fs from "fs";
 import qrTerminal from "qrcode-terminal";
 import os from "os";
 import path from "path";
-import { fileURLToPath } from "url";
 
 const VERSION = "0.1.0";
 const CONTAINER_NAME = "agent-wechat";
 const DEFAULT_PORT = 6174;
 const VNC_PORT = 5900;
-
-// Get monorepo root (cli is at packages/cli)
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const MONOREPO_ROOT = path.resolve(__dirname, "../../..");
+const DEFAULT_REMOTE_IMAGE_REPO = process.env.AGENT_WECHAT_IMAGE_REPO || "ghcr.io/agent-wechat/agent-wechat";
+const DEFAULT_REMOTE_IMAGE_TAG = process.env.AGENT_WECHAT_IMAGE_TAG || "latest";
 
 // Auth token paths
 const TOKEN_DIR = path.join(os.homedir(), ".config", "agent-wechat");
@@ -59,10 +56,62 @@ function getConfig(): Config {
   };
 }
 
-function getImageTag(): string {
+function getLocalImageTag(): string {
   const arch = os.arch();
   if (arch === "arm64") return "agent-wechat:arm64";
   return "agent-wechat:amd64";
+}
+
+function getRemoteImageTag(): string {
+  return `${DEFAULT_REMOTE_IMAGE_REPO}:${DEFAULT_REMOTE_IMAGE_TAG}`;
+}
+
+function imageExists(image: string): boolean {
+  try {
+    execSync(`docker image inspect ${image}`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveImageTag(explicitImage?: string): string {
+  const explicit = explicitImage?.trim();
+  if (explicit) {
+    return explicit;
+  }
+
+  const envImage = process.env.AGENT_WECHAT_IMAGE?.trim();
+  if (envImage) {
+    return envImage;
+  }
+
+  const localImage = getLocalImageTag();
+  if (imageExists(localImage)) {
+    return localImage;
+  }
+  return getRemoteImageTag();
+}
+
+function ensureImageAvailable(image: string): void {
+  if (imageExists(image)) {
+    return;
+  }
+
+  if (image.includes("/")) {
+    console.log(`Image ${image} not found locally. Pulling...`);
+    try {
+      execSync(`docker pull ${image}`, { stdio: "inherit" });
+      return;
+    } catch {
+      console.error(`Failed to pull image: ${image}`);
+      process.exit(1);
+    }
+  }
+
+  console.error(`Image ${image} not found.`);
+  console.error(`Run 'pnpm build:image' first, or set AGENT_WECHAT_IMAGE to a published image.`);
+  process.exit(1);
 }
 
 // Create program
@@ -103,7 +152,10 @@ function getSubscriptionOptions(): SubscriptionClientOptions {
 program
   .command("up")
   .description("Start the WeChat container")
-  .action(cmdUp);
+  .option("--image <image>", "Docker image reference (overrides default resolution)")
+  .action(async (opts: { image?: string }) => {
+    await cmdUp(opts.image);
+  });
 
 program
   .command("down")
@@ -760,8 +812,8 @@ async function cmdSessionDelete(client: WeChatClient, idOrName: string) {
 // Container Commands Implementation
 // ============================================
 
-async function cmdUp() {
-  const image = getImageTag();
+async function cmdUp(explicitImage?: string) {
+  const image = resolveImageTag(explicitImage);
 
   // Check if container already exists
   try {
@@ -784,17 +836,10 @@ async function cmdUp() {
     // No container found, continue to create
   }
 
-  // Check if image exists
-  try {
-    execSync(`docker image inspect ${image}`, { stdio: "ignore" });
-  } catch {
-    console.error(`Image ${image} not found.`);
-    console.error(`Run 'pnpm build:image' first to build the image.`);
-    process.exit(1);
-  }
+  ensureImageAvailable(image);
 
   // Ensure auth token exists
-  const token = ensureToken();
+  ensureToken();
 
   console.log(`Starting container ${CONTAINER_NAME} from ${image}...`);
 

--- a/packages/openclaw-extension/README.md
+++ b/packages/openclaw-extension/README.md
@@ -7,6 +7,13 @@ OpenClaw channel plugin for WeChat. Polls the agent-wechat REST API for inbound 
 - A running agent-wechat container (provides the REST API on port 6174)
 - OpenClaw installed and configured
 
+## Install From npm
+
+```bash
+openclaw plugins install @agent-wechat/wechat
+openclaw plugins enable wechat
+```
+
 ## Development Setup
 
 ### 1. Build

--- a/packages/openclaw-extension/package.json
+++ b/packages/openclaw-extension/package.json
@@ -1,15 +1,25 @@
 {
-  "name": "@agent-wechat/openclaw-wechat",
+  "name": "@agent-wechat/wechat",
   "version": "0.1.0",
   "type": "module",
-  "scripts": {
-    "build": "esbuild index.ts --bundle --format=esm --platform=node --outfile=dist/index.js --external:openclaw"
+  "files": [
+    "dist",
+    "openclaw.plugin.json",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   },
-  "dependencies": {
-    "@thisnick/agent-wechat-shared": "workspace:*"
+  "scripts": {
+    "build": "esbuild index.ts --bundle --format=esm --platform=node --target=node22 --outfile=dist/index.js --external:openclaw --external:openclaw/*",
+    "prepack": "npm run build",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "esbuild": "^0.25.0"
+    "@thisnick/agent-wechat-shared": "workspace:*",
+    "esbuild": "^0.25.0",
+    "typescript": "^5.4.5"
   },
   "openclaw": {
     "extensions": ["./dist/index.js"],
@@ -21,7 +31,7 @@
       "order": 80
     },
     "install": {
-      "npmSpec": "@agent-wechat/openclaw",
+      "npmSpec": "@agent-wechat/wechat",
       "localPath": "packages/openclaw-extension"
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
 
   packages/cli:
     dependencies:
-      '@thisnick/agent-wechat-shared':
-        specifier: workspace:*
-        version: link:../shared
       commander:
         specifier: ^14.0.3
         version: 14.0.3
@@ -27,25 +24,33 @@ importers:
         specifier: ^0.12.0
         version: 0.12.0
     devDependencies:
+      '@thisnick/agent-wechat-shared':
+        specifier: workspace:*
+        version: link:../shared
       '@types/node':
         specifier: ^22
         version: 22.19.11
       '@types/qrcode-terminal':
         specifier: ^0.12.2
         version: 0.12.2
+      esbuild:
+        specifier: ^0.25.0
+        version: 0.25.12
       typescript:
         specifier: ^5.4.5
         version: 5.9.3
 
   packages/openclaw-extension:
-    dependencies:
+    devDependencies:
       '@thisnick/agent-wechat-shared':
         specifier: workspace:*
         version: link:../shared
-    devDependencies:
       esbuild:
         specifier: ^0.25.0
         version: 0.25.12
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
 
   packages/shared:
     dependencies:


### PR DESCRIPTION
## Summary
- make CLI publishable as @agent-wechat/cli with bundled build output and docs
- rename OpenClaw extension package to @agent-wechat/wechat and align install metadata
- add image resolution fallback in CLI (--image, env overrides, local-first then GHCR pull)
- add Changesets config and initial changeset for lockstep package release
- add CI workflow (build/typecheck/cargo check)
- add tag-based release workflow for npm trusted publishing and multi-arch Docker publish
- add release runbook and docs updates

## Notes
- local dependency install/build verification was limited in this environment due intermittent DNS resolution to registry.npmjs.org
- workflow YAML validated locally
