### PR TITLE
feat: binary artifact publishing + CLI update command

### DIFF
--- a/.changeset/binary-publishing.md
+++ b/.changeset/binary-publishing.md
@@ -1,0 +1,8 @@
+---
+"@agent-wechat/cli": minor
+---
+
+Add binary artifact publishing and CLI update command
+
+- Release workflow now publishes standalone `agent-server` binaries (amd64/arm64) as GitHub Release assets alongside Docker images
+- New `wx update` command downloads the binary matching the CLI version and hot-swaps it into the running container via `docker cp` + process restart

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,61 @@ jobs:
         env:
           NPM_CONFIG_PROVENANCE: true
 
+  publish-binary:
+    name: Binary (${{ matrix.arch }})
+    needs: release
+    if: needs.release.outputs.published == 'true'
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            arch: amd64
+            platform: linux/amd64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+            platform: linux/arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version
+        id: version
+        run: |
+          PUBLISHED='${{ needs.release.outputs.publishedPackages }}'
+          VERSION=$(echo "$PUBLISHED" | jq -r '.[0].version // "latest"')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Build binary in Docker
+        run: |
+          RUST_DIR="packages/agent-server-rust"
+          BUILDER_IMAGE="rust:1.93-bookworm"
+
+          docker run --rm \
+            --platform ${{ matrix.platform }} \
+            -v "$PWD/$RUST_DIR:/build:ro" \
+            -v "agent-wechat-cargo-cache-${{ matrix.arch }}:/build/target" \
+            -v "agent-wechat-cargo-registry-${{ matrix.arch }}:/usr/local/cargo/registry" \
+            -w /build \
+            "$BUILDER_IMAGE" \
+            cargo build --release
+
+          # Extract binary from cache volume
+          TMP_CT=$(docker create \
+            -v "agent-wechat-cargo-cache-${{ matrix.arch }}:/target:ro" \
+            "$BUILDER_IMAGE")
+          docker cp "$TMP_CT:/target/release/agent-server" ./agent-server
+          docker rm "$TMP_CT" > /dev/null
+
+      - name: Upload release asset
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          ASSET="agent-server-${VERSION}-linux-${{ matrix.arch }}"
+          mv agent-server "$ASSET"
+          chmod +x "$ASSET"
+          gh release upload "v${VERSION}" "$ASSET" --clobber
+
   publish-docker:
     name: Docker (${{ matrix.arch }})
     needs: release

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -335,6 +335,15 @@ messagesCmd
   });
 
 // ============================================
+// Update Command
+// ============================================
+
+program
+  .command("update")
+  .description("Update the agent-server binary in the running container to match CLI version")
+  .action(cmdUpdate);
+
+// ============================================
 // Debug Commands
 // ============================================
 
@@ -760,6 +769,106 @@ async function cmdSessionDelete(client: WeChatClient, idOrName: string) {
     console.error(`Failed to delete session.`);
     process.exit(1);
   }
+}
+
+// ============================================
+// Update Command Implementation
+// ============================================
+
+async function cmdUpdate() {
+  const version = VERSION;
+  console.log(`Updating agent-server to v${version}...`);
+
+  // Find running container
+  let container: string;
+  try {
+    container = execSync(
+      `docker ps --filter "name=agent-wechat" --format "{{.Names}}" | head -1`,
+      { encoding: "utf-8" }
+    ).trim();
+  } catch {
+    container = "";
+  }
+  if (!container) {
+    console.error("No running agent-wechat container found.");
+    process.exit(1);
+  }
+
+  // Detect container architecture
+  let arch: string;
+  const containerArch = execSync(
+    `docker inspect --format "{{.Architecture}}" "${container}"`,
+    { encoding: "utf-8" }
+  ).trim();
+  switch (containerArch) {
+    case "amd64":
+      arch = "amd64";
+      break;
+    case "arm64":
+      arch = "arm64";
+      break;
+    default:
+      // Fallback to host arch
+      const uname = execSync("uname -m", { encoding: "utf-8" }).trim();
+      arch = uname === "x86_64" ? "amd64" : "arm64";
+  }
+
+  const assetName = `agent-server-${version}-linux-${arch}`;
+  const tmpFile = path.join(os.tmpdir(), assetName);
+
+  // Download binary from GitHub Releases
+  console.log(`Downloading ${assetName}...`);
+  try {
+    execSync(
+      `gh release download "v${version}" --repo thisnick/agent-wechat -p "${assetName}" -D "${os.tmpdir()}" --clobber`,
+      { stdio: "inherit" }
+    );
+  } catch {
+    console.error(
+      `Failed to download ${assetName} from GitHub Releases.\n` +
+      `Make sure v${version} has been released with binary assets.\n` +
+      `You may need to install the GitHub CLI: https://cli.github.com`
+    );
+    process.exit(1);
+  }
+
+  // Deploy into container
+  console.log(`Deploying to ${container}...`);
+  execSync(`docker cp "${tmpFile}" "${container}:/opt/agent-server/agent-server"`, {
+    stdio: "inherit",
+  });
+
+  // Restart server process (entrypoint loop brings it back)
+  execSync(
+    `docker exec "${container}" pkill -f "/opt/agent-server/agent-server" 2>/dev/null || true`,
+    { stdio: "inherit" }
+  );
+
+  // Clean up
+  try {
+    fs.unlinkSync(tmpFile);
+  } catch {
+    // ignore
+  }
+
+  console.log("Server restarting with new binary.");
+
+  // Wait for health check
+  console.log("Waiting for server...");
+  const config = getConfig();
+  for (let i = 0; i < 15; i++) {
+    await new Promise((r) => setTimeout(r, 1000));
+    try {
+      const resp = await fetch(`${config.serverUrl}/health`);
+      if (resp.ok) {
+        console.log("Server is ready!");
+        return;
+      }
+    } catch {
+      // not ready yet
+    }
+  }
+  console.log("Server did not become ready in time. Check logs with: wx logs");
 }
 
 // ============================================


### PR DESCRIPTION
## Summary

- **Release workflow**: new `publish-binary` job builds standalone `agent-server` binaries (amd64/arm64) in Docker and uploads them as GitHub Release assets alongside Docker images
- **CLI**: new `wx update` command downloads the binary matching the CLI's own version from GitHub Releases and hot-swaps it into the running container (`docker cp` + `pkill`)

This enables updating the server binary without rebuilding the full Docker image — same hot-swap pattern as `dev-deploy.sh`.

## Test plan

- [ ] Push a changeset to main → verify release creates GitHub Release with `agent-server-{version}-linux-{amd64,arm64}` assets
- [ ] Run `wx update` locally → binary downloaded, swapped into container, server restarts, `/health` returns ok
- [ ] Companion PR in agent-wechat-infra adds `deploy-binary` workflow + script for VPS deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)