### PR TITLE
fix: remove read-only mount flag in binary publish job

### DIFF
--- a/.changeset/fix-binary-publish.md
+++ b/.changeset/fix-binary-publish.md
@@ -1,0 +1,7 @@
+---
+"@agent-wechat/cli": patch
+---
+
+Fix binary publish job in release workflow
+
+- Remove read-only flag from Docker source mount that prevented container startup (exit code 125)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
 
           docker run --rm \
             --platform ${{ matrix.platform }} \
-            -v "$PWD/$RUST_DIR:/build:ro" \
+            -v "$PWD/$RUST_DIR:/build" \
             -v "agent-wechat-cargo-cache-${{ matrix.arch }}:/build/target" \
             -v "agent-wechat-cargo-registry-${{ matrix.arch }}:/usr/local/cargo/registry" \
             -w /build \


### PR DESCRIPTION
The publish-binary job failed with Docker exit code 125 because the
source directory was mounted read-only (:ro), preventing Docker from
creating the /build/target mount point for the cargo cache volume on
a fresh CI checkout where the target/ directory doesn't exist.

https://claude.ai/code/session_01NfMnRayQufT7qRxTrkTQ9o