### PR TITLE
fix: use Ubuntu 22.04-based builder to match runtime glibc version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,10 +89,15 @@ jobs:
           VERSION=$(echo "$PUBLISHED" | jq -r '.[0].version // "latest"')
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+      - name: Build builder image (Ubuntu 22.04 + Rust)
+        run: |
+          docker build -t agent-wechat-builder:latest \
+            -f docker/Dockerfile.builder docker/
+
       - name: Build binary in Docker
         run: |
           RUST_DIR="packages/agent-server-rust"
-          BUILDER_IMAGE="rust:1.93-bookworm"
+          BUILDER_IMAGE="agent-wechat-builder:latest"
 
           docker run --rm \
             --platform ${{ matrix.platform }} \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,16 +1,29 @@
 # ============================================
 # Stage 1: Build the Rust server binary
 # ============================================
-FROM rust:1.93-bookworm AS builder
+# Use the same Ubuntu version as the runtime stage so the compiled binary
+# links against a compatible glibc (2.35).  Building on a newer distro
+# (e.g. Debian Bookworm with glibc 2.36) can produce binaries that fail
+# at runtime with "GLIBC_2.36 not found".
+FROM ubuntu:22.04 AS builder
 
 ARG BUILD_MODE=release
 
+ENV DEBIAN_FRONTEND=noninteractive
+# Rust installation
+ENV RUSTUP_HOME=/usr/local/rustup
+ENV CARGO_HOME=/usr/local/cargo
+ENV PATH="/usr/local/cargo/bin:$PATH"
+
 WORKDIR /build
 
-# Install build dependencies for bundled sqlcipher + openssl
+# Install build dependencies + Rust toolchain
 RUN apt-get update && apt-get install -y \
-    pkg-config \
-    && rm -rf /var/lib/apt/lists/*
+    curl build-essential pkg-config \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+       | sh -s -- -y --default-toolchain stable --profile minimal \
+    && rustup show
 
 # Copy manifests first for dependency caching
 COPY agent-server-rust/Cargo.toml agent-server-rust/Cargo.lock* ./

--- a/docker/Dockerfile.builder
+++ b/docker/Dockerfile.builder
@@ -1,0 +1,15 @@
+# Rust builder image based on Ubuntu 22.04 (glibc 2.35)
+# Ensures compiled binaries are compatible with the runtime container.
+# Used by dev-deploy.sh and CI workflows.
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV RUSTUP_HOME=/usr/local/rustup
+ENV CARGO_HOME=/usr/local/cargo
+ENV PATH="/usr/local/cargo/bin:$PATH"
+
+RUN apt-get update && apt-get install -y \
+    curl build-essential pkg-config \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+       | sh -s -- -y --default-toolchain stable --profile minimal

--- a/scripts/dev-deploy.sh
+++ b/scripts/dev-deploy.sh
@@ -10,7 +10,8 @@ set -euo pipefail
 
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 RUST_DIR="$ROOT_DIR/packages/agent-server-rust"
-BUILDER_IMAGE="rust:1.93-bookworm"
+# Use Ubuntu 22.04-based builder to match runtime glibc (2.35)
+BUILDER_IMAGE="agent-wechat-builder:latest"
 CACHE_VOLUME="agent-wechat-cargo-cache"
 
 CONTAINER=""
@@ -63,6 +64,10 @@ if [ "$BUILD_MODE" = "debug" ]; then
   CARGO_ARGS=""
   BINARY_DIR="debug"
 fi
+
+# Build the builder image (cached after first run)
+echo "==> Ensuring builder image exists (Ubuntu 22.04 + Rust)"
+docker build -q -t "$BUILDER_IMAGE" -f "$ROOT_DIR/docker/Dockerfile.builder" "$ROOT_DIR/docker"
 
 echo "==> Building in Docker ($PLATFORM, mode=$BUILD_MODE)"
 docker run --rm \

--- a/scripts/dev-watch.sh
+++ b/scripts/dev-watch.sh
@@ -10,7 +10,8 @@ set -euo pipefail
 
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 RUST_DIR="$ROOT_DIR/packages/agent-server-rust"
-BUILDER_IMAGE="rust:1.93-bookworm"
+# Use Ubuntu 22.04-based builder to match runtime glibc (2.35)
+BUILDER_IMAGE="agent-wechat-builder:latest"
 CACHE_VOLUME="agent-wechat-cargo-cache"
 
 CONTAINER=""
@@ -54,6 +55,10 @@ case "$CONTAINER_ARCH" in
     esac
     ;;
 esac
+
+# Build the builder image (cached after first run)
+echo "==> Ensuring builder image exists (Ubuntu 22.04 + Rust)"
+docker build -q -t "$BUILDER_IMAGE" -f "$ROOT_DIR/docker/Dockerfile.builder" "$ROOT_DIR/docker"
 
 echo "Watching $RUST_DIR"
 echo "  Builder:   $BUILDER_IMAGE ($PLATFORM)"


### PR DESCRIPTION
The builder stage used rust:1.93-bookworm (Debian 12, glibc 2.36) while
the runtime stage uses ubuntu:22.04 (glibc 2.35). This mismatch can
produce binaries that fail at runtime with "GLIBC_2.36 not found".

Switch all build paths (Dockerfile, dev-deploy, dev-watch, CI release)
to use an Ubuntu 22.04-based builder image with Rust installed via
rustup, ensuring the compiled binary links against glibc 2.35.

https://claude.ai/code/session_017YN23huH2B5VX8yJhiGKtx