### PR TITLE
Optimize CI workflow to run only on relevant file changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,25 @@ name: CI
 
 on:
   pull_request:
+    paths:
+      - 'packages/**'
+      - 'pnpm-lock.yaml'
+      - 'package.json'
+      - 'pnpm-workspace.yaml'
+      - 'turbo.json'
+      - 'tsconfig.json'
+      - '.github/workflows/ci.yml'
   push:
-    branches:
+    branches-ignore:
       - main
+    paths:
+      - 'packages/**'
+      - 'pnpm-lock.yaml'
+      - 'package.json'
+      - 'pnpm-workspace.yaml'
+      - 'turbo.json'
+      - 'tsconfig.json'
+      - '.github/workflows/ci.yml'
 
 jobs:
   build-and-check:


### PR DESCRIPTION
## Summary
Updated the CI workflow to only trigger on changes to relevant files, reducing unnecessary workflow runs and improving CI efficiency.

## Key Changes
- Added `paths` filter to pull request trigger to only run CI when files in `packages/`, configuration files, or workflow files are modified
- Changed push trigger from `branches: [main]` to `branches-ignore: [main]` with `paths` filter to run CI on all branches except main when relevant files change
- Relevant files monitored include:
  - `packages/**` - source code
  - `pnpm-lock.yaml` - dependency lock file
  - `package.json` - root package configuration
  - `pnpm-workspace.yaml` - workspace configuration
  - `turbo.json` - build system configuration
  - `tsconfig.json` - TypeScript configuration
  - `.github/workflows/ci.yml` - this workflow file

## Benefits
- Prevents CI runs when only documentation, README, or other non-code files are modified
- Reduces CI resource usage and feedback time for developers
- Maintains comprehensive checks for all code and configuration changes

https://claude.ai/code/session_01Pd5f8hLaWZ61fdQZmg8Wz3