### PR TITLE
chore: remove temporary NPM_TOKEN from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,9 +64,6 @@ jobs:
           fi
         env:
           NPM_CONFIG_PROVENANCE: true
-          # NPM_TOKEN needed for first publish of new packages (OIDC requires package to exist).
-          # Remove after @agent-wechat/wechaty-puppet is published and OIDC is configured.
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-binary:
     name: Binary (${{ matrix.arch }})


### PR DESCRIPTION
## Summary

- Remove `NODE_AUTH_TOKEN` / `NPM_TOKEN` fallback from the publish step now that `@agent-wechat/wechaty-puppet` exists on npm and OIDC trusted publishing can handle it

## Test plan

- [ ] Next release publishes successfully via OIDC (verify OIDC is configured for `@agent-wechat/wechaty-puppet` on npmjs.com)

🤖 Generated with [Claude Code](https://claude.com/claude-code)