### PR TITLE
fix: puppet login events not emitted

### DIFF
--- a/.changeset/fix-login-events.md
+++ b/.changeset/fix-login-events.md
@@ -1,0 +1,5 @@
+---
+"@agent-wechat/wechaty-puppet": patch
+---
+
+Fix login event handling — QR scan events were not emitted due to incorrect event discriminator

--- a/packages/wechaty-puppet/README.md
+++ b/packages/wechaty-puppet/README.md
@@ -4,7 +4,11 @@ Wechaty Puppet for [agent-wechat](https://github.com/thisnick/agent-wechat). Bri
 
 ## Prerequisites
 
-- **An agent-wechat server** running (Docker container or via `wx up`)
+- **An agent-wechat server** running — set up via the CLI or from the [agent-wechat repo](https://github.com/thisnick/agent-wechat):
+  ```bash
+  npx @agent-wechat/cli up     # starts the Docker container
+  npx @agent-wechat/cli login   # scan QR to log in
+  ```
 - **Node.js >= 22**
 
 ## Install
@@ -27,8 +31,7 @@ const bot = WechatyBuilder.build({
 })
 
 bot.on('scan', (qrcode, status) => {
-  console.log(`Scan QR code: status=${status}`)
-  // Use qrcode-terminal or similar to display the QR
+  console.log(`Scan QR Code to login: ${status}\nhttps://wechaty.js.org/qrcode/${encodeURIComponent(qrcode)}`)
 })
 
 bot.on('login', user => console.log(`Logged in: ${user}`))
@@ -85,4 +88,5 @@ The puppet connects to the agent-wechat REST API (Rust server running inside a D
 - **Messages**: Polls `GET /api/chats` for unreads, then `GET /api/messages/{chatId}` for new messages
 - **Sending**: `POST /api/messages/send` with text, image, or file payloads
 - **Media**: `GET /api/messages/{chatId}/media/{localId}` for image/voice/video downloads
-- **Contacts/Rooms**: Derived from `GET /api/chats` (contacts = non-group chats, rooms = group chats)
+- **Contacts**: Full address book via `GET /api/contacts`
+- **Rooms**: Derived from `GET /api/chats` (group chats)

--- a/packages/wechaty-puppet/scripts/test-ding-dong.ts
+++ b/packages/wechaty-puppet/scripts/test-ding-dong.ts
@@ -30,12 +30,7 @@ const bot = WechatyBuilder.build({
 bot.on('scan', (qrcode, status) => {
   console.log(`[scan] status=${status}`)
   if (qrcode) {
-    try {
-      const qr = require('qrcode-terminal')
-      qr.generate(qrcode, { small: true })
-    } catch {
-      console.log(`  (install qrcode-terminal to display QR in terminal)`)
-    }
+    console.log(`Scan QR Code to login: https://wechaty.js.org/qrcode/${encodeURIComponent(qrcode)}`)
   }
 })
 

--- a/packages/wechaty-puppet/scripts/test-puppet.ts
+++ b/packages/wechaty-puppet/scripts/test-puppet.ts
@@ -27,7 +27,7 @@ const puppet = new PuppetAgentWeChat({
 puppet.on('scan', (payload) => {
   console.log(`[scan] status=${payload.status}`)
   if (payload.qrcode) {
-    console.log(`[scan] qrcode available (${payload.qrcode.length} chars)`)
+    console.log(`Scan QR Code to login: https://wechaty.js.org/qrcode/${encodeURIComponent(payload.qrcode)}`)
   }
 })
 

--- a/packages/wechaty-puppet/src/puppet-agent-wechat.ts
+++ b/packages/wechaty-puppet/src/puppet-agent-wechat.ts
@@ -145,29 +145,33 @@ export class PuppetAgentWeChat extends PUPPET.Puppet {
   }
 
   private handleLoginEvent(event: LoginSubscriptionEvent): void {
-    if ('qr' in event) {
-      const qr = event.qr as { qrData?: string; qrDataUrl?: string }
-      const qrcode = qr.qrData ?? qr.qrDataUrl ?? ''
-      this.emit('scan', {
-        qrcode,
-        status: PUPPET.types.ScanStatus.Waiting,
-      })
-    } else if ('phone_confirm' in event) {
-      this.emit('scan', {
-        qrcode: '',
-        status: PUPPET.types.ScanStatus.Scanned,
-      })
-    } else if ('login_success' in event) {
-      const data = event.login_success as { userId?: string }
-      const userId = data.userId ?? 'unknown'
-      void this.onLoginSuccess(userId)
-    } else if ('login_timeout' in event) {
-      this.emit('error', { data: 'Login timed out' })
-    } else if ('error' in event) {
-      const data = event.error as { message?: string }
-      this.emit('error', { data: data.message ?? 'Login error' })
-    } else if ('status' in event) {
-      log.verbose('PuppetAgentWeChat', 'Login status: %s', JSON.stringify(event.status))
+    switch (event.type) {
+      case 'qr': {
+        const qrcode = event.qrData ?? event.qrDataUrl ?? ''
+        this.emit('scan', {
+          qrcode,
+          status: PUPPET.types.ScanStatus.Waiting,
+        })
+        break
+      }
+      case 'phone_confirm':
+        this.emit('scan', {
+          qrcode: '',
+          status: PUPPET.types.ScanStatus.Scanned,
+        })
+        break
+      case 'login_success':
+        void this.onLoginSuccess(event.userId ?? 'unknown')
+        break
+      case 'login_timeout':
+        this.emit('error', { data: 'Login timed out' })
+        break
+      case 'error':
+        this.emit('error', { data: event.message ?? 'Login error' })
+        break
+      case 'status':
+        log.verbose('PuppetAgentWeChat', 'Login status: %s', event.message)
+        break
     }
   }
 


### PR DESCRIPTION
## Summary

- Fix `handleLoginEvent` — used `'qr' in event` (checking for a key named `qr`) instead of `event.type === 'qr'` (tagged union discriminator). No scan/login events were ever dispatched to Wechaty. Switched to `switch (event.type)` for type-safe dispatch.
- Update README: QR URL in scan example, setup instructions with CLI commands and repo link, correct contacts endpoint description
- Update test scripts to show QR login URL instead of just logging qrcode length

## Test plan

- [x] `pnpm build` passes
- [x] Verified WebSocket receives `{"type":"qr","qrData":"..."}` events
- [x] `pnpm test:puppet` shows QR login URL when not logged in

🤖 Generated with [Claude Code](https://claude.com/claude-code)