### PR TITLE
fix: support @agent /cmd in WeChat groups

### DIFF
--- a/.changeset/wechat-mention-command-normalization.md
+++ b/.changeset/wechat-mention-command-normalization.md
@@ -1,0 +1,10 @@
+---
+"@agent-wechat/wechat": patch
+---
+
+Restore reliable group command handling for mention-prefixed commands such as `@agent /compact`.
+
+- Normalize WeChat command bodies so leading group mention tokens are stripped before command detection/authorization.
+- Use command-aware detection (`isControlCommandMessage`) in monitor gating paths.
+- Add a WeChat mention adapter so downstream command parsing also sees normalized command text.
+- Add tests covering mention-prefixed command normalization behavior.

--- a/packages/openclaw-extension/src/access-control.test.ts
+++ b/packages/openclaw-extension/src/access-control.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import type { ResolvedWeChatAccount } from "./types.ts";
 import {
+  normalizeWeChatCommandBody,
   normalizeWeChatAllowFrom,
   normalizeWeChatId,
   resolveWeChatCommandAuthorization,
@@ -42,6 +43,37 @@ test("normalizeWeChatAllowFrom dedupes and preserves wildcard", () => {
     "wechat:wxid_xyz",
   ]);
   assert.deepEqual(entries, ["wxid_abc", "*", "wxid_xyz"]);
+});
+
+test("normalizeWeChatCommandBody strips leading mentions before slash commands in groups", () => {
+  assert.equal(
+    normalizeWeChatCommandBody("  @agent /compact  ", {
+      isGroup: true,
+      wasMentioned: true,
+    }),
+    "/compact",
+  );
+  assert.equal(
+    normalizeWeChatCommandBody("@agent\u2005/compact focus", {
+      isGroup: true,
+      wasMentioned: true,
+    }),
+    "/compact focus",
+  );
+  assert.equal(
+    normalizeWeChatCommandBody("@agent hello /compact", {
+      isGroup: true,
+      wasMentioned: true,
+    }),
+    "@agent hello /compact",
+  );
+  assert.equal(
+    normalizeWeChatCommandBody("@agent /compact", {
+      isGroup: true,
+      wasMentioned: false,
+    }),
+    "@agent /compact",
+  );
 });
 
 test("resolveWeChatPolicyContext resolves overrides and effective allowlists", () => {

--- a/packages/openclaw-extension/src/access-control.ts
+++ b/packages/openclaw-extension/src/access-control.ts
@@ -38,6 +38,10 @@ export type WeChatMentionGateResult = {
   shouldBypassMention: boolean;
 };
 
+const INVISIBLE_TEXT_RE = /[\u200b-\u200f\u202a-\u202e\u2060-\u206f]/g;
+const MENTION_SEPARATOR_RE = /[\s\u2005]+/u;
+const WECHAT_MENTION_TOKEN_RE = /^[@＠][^\s\u2005]+$/u;
+
 function unique(values: string[]): string[] {
   return Array.from(new Set(values));
 }
@@ -80,6 +84,47 @@ export function normalizeWeChatAllowFrom(values: Array<string | number> | null |
     .map((entry) => (entry === "*" ? "*" : normalizeWeChatId(entry)))
     .filter(Boolean);
   return unique(normalized);
+}
+
+function findCommandTokenStart(input: string): number {
+  const match = /(?:^|\s)([/!][A-Za-z])/u.exec(input);
+  if (!match) {
+    return -1;
+  }
+  const whole = match[0] ?? "";
+  const startsWithSpace = whole.startsWith(" ");
+  return (match.index ?? 0) + (startsWithSpace ? 1 : 0);
+}
+
+export function normalizeWeChatCommandBody(
+  raw: string,
+  params?: { isGroup?: boolean; wasMentioned?: boolean },
+): string {
+  const trimmed = raw.replace(INVISIBLE_TEXT_RE, "").trim();
+  if (!trimmed) {
+    return "";
+  }
+  const isGroup = params?.isGroup === true;
+  const wasMentioned = params?.wasMentioned === true;
+  if (!isGroup || !wasMentioned) {
+    return trimmed;
+  }
+  const commandStart = findCommandTokenStart(trimmed);
+  if (commandStart < 0) {
+    return trimmed;
+  }
+  const prefix = trimmed.slice(0, commandStart).trim();
+  if (!prefix) {
+    return trimmed.slice(commandStart).trimStart();
+  }
+  const prefixTokens = prefix
+    .split(MENTION_SEPARATOR_RE)
+    .map((token) => token.trim())
+    .filter(Boolean);
+  if (prefixTokens.length > 0 && prefixTokens.every((token) => WECHAT_MENTION_TOKEN_RE.test(token))) {
+    return trimmed.slice(commandStart).trimStart();
+  }
+  return trimmed;
 }
 
 export function isWeChatSenderAllowed(

--- a/packages/openclaw-extension/src/channel.ts
+++ b/packages/openclaw-extension/src/channel.ts
@@ -10,7 +10,7 @@ import { WeChatClient } from "@agent-wechat/shared";
 import { loginStart, loginWait, loginTerminal } from "./login.js";
 // loginWait still used by gateway.loginWithQrWait
 import { createWeChatLoginTool } from "./agent-tools.js";
-import { normalizeWeChatId } from "./access-control.js";
+import { normalizeWeChatCommandBody, normalizeWeChatId } from "./access-control.js";
 
 const meta: ChannelMeta = {
   id: "wechat",
@@ -137,6 +137,15 @@ export const wechatPlugin: ChannelPlugin<ResolvedWeChatAccount> = {
       }
       return wechat.groups?.["*"]?.requireMention ?? true;
     },
+  },
+
+  // ---- Mention adapter ----
+  mentions: {
+    stripMentions: ({ text, ctx }) =>
+      normalizeWeChatCommandBody(text, {
+        isGroup: ctx.ChatType === "group",
+        wasMentioned: ctx.WasMentioned === true,
+      }),
   },
 
   // ---- Messaging adapter ----

--- a/packages/openclaw-extension/src/monitor.ts
+++ b/packages/openclaw-extension/src/monitor.ts
@@ -5,6 +5,7 @@ import type { ResolvedWeChatAccount } from "./types.js";
 import { getWeChatRuntime } from "./runtime.js";
 import { resolveWeChatAccount } from "./types.js";
 import {
+  normalizeWeChatCommandBody,
   resolveWeChatCommandAuthorization,
   resolveWeChatInboundAccessDecision,
   resolveWeChatMentionGate,
@@ -271,6 +272,7 @@ async function prepareMessage(
   const isGroup = chatId.includes("@chatroom");
   const senderId = msg.sender ?? chatId;
   const senderName = msg.senderName ?? msg.sender ?? chat.name;
+  const wasMentioned = isGroup && (msg.isMentioned === true);
 
   const access = resolveWeChatInboundAccessDecision({
     isGroup,
@@ -368,7 +370,10 @@ async function prepareMessage(
   return {
     msg,
     rawBody,
-    commandBody: rawBody,
+    commandBody: normalizeWeChatCommandBody(rawBody, {
+      isGroup,
+      wasMentioned,
+    }),
     mediaPath,
     mediaMime,
     senderName,
@@ -376,7 +381,7 @@ async function prepareMessage(
     isGroup,
     timestamp,
     hasMedia,
-    isMentioned: isGroup && (msg.isMentioned === true),
+    isMentioned: wasMentioned,
   };
 }
 
@@ -438,7 +443,8 @@ async function dispatchSegment(
     `${mediaPath ? ` media=${mediaPath}` : ""}`,
   );
 
-  const hasControlCommand = allowTextCommands && core.channel.text.hasControlCommand(commandBody, cfg);
+  const hasControlCommand =
+    allowTextCommands && core.channel.commands.isControlCommandMessage(commandBody, cfg);
   const commandAuthorized = await resolveWeChatCommandAuthorization({
     cfg,
     rawBody: commandBody,
@@ -848,7 +854,8 @@ async function processUnreadChat(
   const isGroup = chatId.includes("@chatroom");
   let clearBufferedHistory = false;
   const hasControlCommandInWindow =
-    allowTextCommands && processed.some((pm) => core.channel.text.hasControlCommand(pm.commandBody, cfg));
+    allowTextCommands &&
+    processed.some((pm) => core.channel.commands.isControlCommandMessage(pm.commandBody, cfg));
   if (isGroup && groupHistory) {
     if (policy.requireMention) {
       const hasMention = processed.some(pm => pm.isMentioned);


### PR DESCRIPTION
## Summary
- restore reliable mention-prefixed command behavior in WeChat groups (e.g. @agent /compact)
- add command-body normalization that strips leading mention tokens when group mention is detected
- switch WeChat monitor command detection to isControlCommandMessage for parity with command pipeline
- add WeChat mentions.stripMentions adapter so downstream command parsing sees normalized command text
- add unit tests for mention-prefixed command normalization
- add a new changeset for @agent-wechat/wechat

## Validation
- pnpm --filter @agent-wechat/wechat test
- pnpm --filter @agent-wechat/wechat typecheck
- pnpm --filter @agent-wechat/wechat build
