### PR TITLE
Fix WeChat mention parsing for multi-word agent names

### DIFF
--- a/.changeset/ten-icons-fold.md
+++ b/.changeset/ten-icons-fold.md
@@ -1,0 +1,5 @@
+---
+"@agent-wechat/wechat": patch
+---
+
+Fix @agent /command regex to support multi-word agent display names by using WeChat's hair space (U+2005) as the mention boundary instead of splitting on all whitespace

--- a/packages/openclaw-extension/src/access-control.test.ts
+++ b/packages/openclaw-extension/src/access-control.test.ts
@@ -47,7 +47,7 @@ test("normalizeWeChatAllowFrom dedupes and preserves wildcard", () => {
 
 test("normalizeWeChatCommandBody strips leading mentions before slash commands in groups", () => {
   assert.equal(
-    normalizeWeChatCommandBody("  @agent /compact  ", {
+    normalizeWeChatCommandBody("@agent\u2005/compact", {
       isGroup: true,
       wasMentioned: true,
     }),
@@ -73,6 +73,46 @@ test("normalizeWeChatCommandBody strips leading mentions before slash commands i
       wasMentioned: false,
     }),
     "@agent /compact",
+  );
+  // Multi-word agent name with hair space separator
+  assert.equal(
+    normalizeWeChatCommandBody("@Agent Name\u2005/compact", {
+      isGroup: true,
+      wasMentioned: true,
+    }),
+    "/compact",
+  );
+  // Multi-word name with command args
+  assert.equal(
+    normalizeWeChatCommandBody("@Agent Name\u2005/compact focus", {
+      isGroup: true,
+      wasMentioned: true,
+    }),
+    "/compact focus",
+  );
+  // Multiple multi-word mentions
+  assert.equal(
+    normalizeWeChatCommandBody("@Agent Name\u2005@Other Person\u2005/status", {
+      isGroup: true,
+      wasMentioned: true,
+    }),
+    "/status",
+  );
+  // No hair space — no stripping (not a real WeChat mention)
+  assert.equal(
+    normalizeWeChatCommandBody("@Agent Name /compact", {
+      isGroup: true,
+      wasMentioned: true,
+    }),
+    "@Agent Name /compact",
+  );
+  // Full-width @ with multi-word name
+  assert.equal(
+    normalizeWeChatCommandBody("\uFF20Agent Name\u2005/compact", {
+      isGroup: true,
+      wasMentioned: true,
+    }),
+    "/compact",
   );
 });
 

--- a/packages/openclaw-extension/src/access-control.ts
+++ b/packages/openclaw-extension/src/access-control.ts
@@ -39,8 +39,7 @@ export type WeChatMentionGateResult = {
 };
 
 const INVISIBLE_TEXT_RE = /[\u200b-\u200f\u202a-\u202e\u2060-\u206f]/g;
-const MENTION_SEPARATOR_RE = /[\s\u2005]+/u;
-const WECHAT_MENTION_TOKEN_RE = /^[@＠][^\s\u2005]+$/u;
+const WECHAT_MENTION_START_RE = /^[@＠]/u;
 
 function unique(values: string[]): string[] {
   return Array.from(new Set(values));
@@ -113,15 +112,26 @@ export function normalizeWeChatCommandBody(
   if (commandStart < 0) {
     return trimmed;
   }
-  const prefix = trimmed.slice(0, commandStart).trim();
+  const rawPrefix = trimmed.slice(0, commandStart);
+  const prefix = rawPrefix.trim();
   if (!prefix) {
     return trimmed.slice(commandStart).trimStart();
   }
-  const prefixTokens = prefix
-    .split(MENTION_SEPARATOR_RE)
+  // WeChat terminates each @-mention with a hair space (U+2005).
+  // Split on hair space to preserve spaces within display names
+  // (e.g. "@Agent Name\u2005" is a single mention token).
+  // The hair space may be within rawPrefix (between multiple mentions)
+  // or at trimmed[commandStart] (between last mention and the command).
+  const hasHairSpace = rawPrefix.includes("\u2005") || trimmed[commandStart] === "\u2005";
+  if (!hasHairSpace) {
+    return trimmed;
+  }
+  const mentionRegion = rawPrefix + (trimmed[commandStart] === "\u2005" ? "\u2005" : "");
+  const prefixTokens = mentionRegion
+    .split(/\u2005+/)
     .map((token) => token.trim())
     .filter(Boolean);
-  if (prefixTokens.length > 0 && prefixTokens.every((token) => WECHAT_MENTION_TOKEN_RE.test(token))) {
+  if (prefixTokens.length > 0 && prefixTokens.every((token) => WECHAT_MENTION_START_RE.test(token))) {
     return trimmed.slice(commandStart).trimStart();
   }
   return trimmed;


### PR DESCRIPTION
## Summary
Fixed the WeChat command normalization logic to correctly handle multi-word agent display names by using WeChat's hair space character (U+2005) as the mention boundary instead of splitting on all whitespace.

## Key Changes
- Updated `normalizeWeChatCommandBody()` to recognize that WeChat terminates each @-mention with a hair space (U+2005), which allows proper parsing of mentions containing spaces (e.g., "@Agent Name")
- Replaced the generic `MENTION_SEPARATOR_RE` regex that split on all whitespace with logic that specifically looks for hair space boundaries
- Simplified `WECHAT_MENTION_TOKEN_RE` to `WECHAT_MENTION_START_RE` to only check if a token starts with @ or ＠, since the hair space now properly delimits mention boundaries
- Added validation to only apply mention stripping when hair spaces are actually present, preventing false positives on non-WeChat formatted text
- Expanded test coverage with cases for multi-word agent names, multiple mentions, full-width @ symbols, and edge cases

## Implementation Details
The key insight is that WeChat uses the hair space character (U+2005) as a delimiter between mention tokens, not regular spaces. This allows display names with spaces to be treated as single mention units. The updated logic:
1. Checks if hair spaces exist in the prefix or at the command boundary
2. Splits only on hair spaces to preserve spaces within display names
3. Validates that all resulting tokens are valid @-mentions before stripping them
4. Falls back to returning the original text if the format doesn't match WeChat's mention pattern

https://claude.ai/code/session_012PtRoqvvb2GnF6pP5f2hFA