### PR TITLE
feat: parse merged-forward (chat history) messages

### DIFF
--- a/.changeset/parse-merged-forward.md
+++ b/.changeset/parse-merged-forward.md
@@ -1,0 +1,12 @@
+---
+"@agent-wechat/agent-server": patch
+---
+
+feat: parse merged-forward (chat history) messages (type 49, subtype 19)
+
+Previously, "Combine and Forward" messages only showed the title (e.g.
+"Chat History of Group X"). Now the agent extracts the full
+`<recorditem>` XML and renders each forwarded message as
+`sender: content`, giving agents visibility into the actual conversation.
+
+Closes #126

--- a/packages/agent-server-rust/src/tools/wechat_messages.rs
+++ b/packages/agent-server-rust/src/tools/wechat_messages.rs
@@ -93,6 +93,47 @@ fn clean_content(content: &str, msg_type: i32) -> String {
                     }
                     parts.join("\n")
                 }
+                // Merged forward / chat history (19)
+                19 => {
+                    let mut parts = Vec::new();
+                    parts.push(format!("[Chat History] {title}"));
+                    // recorditem is XML-escaped inside the appmsg
+                    if let Some(record_raw) = extract_xml_tag(content, "recorditem") {
+                        let record = record_raw
+                            .replace("&lt;", "<")
+                            .replace("&gt;", ">")
+                            .replace("&amp;", "&")
+                            .replace("&quot;", "\"");
+                        // Extract each <dataitem> block
+                        let mut search_from = 0usize;
+                        while let Some(start) = record[search_from..].find("<dataitem") {
+                            let abs_start = search_from + start;
+                            if let Some(end_offset) = record[abs_start..].find("</dataitem>") {
+                                let item = &record[abs_start..abs_start + end_offset + "</dataitem>".len()];
+                                let sender_name = extract_xml_tag(item, "sourcename")
+                                    .or_else(|| extract_xml_tag(item, "displayname"))
+                                    .unwrap_or_default();
+                                let data_title = extract_xml_tag(item, "datatitle")
+                                    .or_else(|| extract_xml_tag(item, "datadesc"))
+                                    .unwrap_or_else(|| "[media]".to_string());
+                                if !sender_name.is_empty() {
+                                    parts.push(format!("{sender_name}: {data_title}"));
+                                } else {
+                                    parts.push(data_title);
+                                }
+                                search_from = abs_start + end_offset + "</dataitem>".len();
+                            } else {
+                                break;
+                            }
+                        }
+                    }
+                    if parts.len() == 1 {
+                        // Only title, no items parsed — fall back to title
+                        title
+                    } else {
+                        parts.join("\n")
+                    }
+                }
                 _ => {
                     if title.is_empty() {
                         content.to_string()


### PR DESCRIPTION
## Summary

Parse appmsg subtype 19 (merged forward / "Combine and Forward" / chat history) messages by extracting the XML-escaped `<recorditem>` content and rendering each `<dataitem>` as `sender: message`.

**Before:** Agents only see the title, e.g. `Chat History of Group X` — the actual forwarded messages are invisible.

**After:** Each forwarded message is extracted and rendered:
```
[Chat History] Chat History of Group X
Alice: Hey, did you see this?
Bob: Yes, looks great!
Charlie: [media]
```

## Changes

- `packages/agent-server-rust/src/tools/wechat_messages.rs`: Add match arm for appmsg subtype 19
  - Decode XML-escaped `<recorditem>` (`&lt;` → `<`, etc.)
  - Iterate `<dataitem>` blocks, extract `<sourcename>`/`<displayname>` and `<datatitle>`/`<datadesc>`
  - Fall back to `[media]` when no text content is available
  - Fall back to title-only when no `<dataitem>` blocks are found

## Testing

Tested in production with real merged-forward messages from WeChat group chats containing 100+ messages, mixed media types, and nested forwards. The agent now correctly reads and responds to forwarded conversation content.

Closes #126