### PR TITLE
fix: sync /api/status loginState with actual logged_in_user from DB

### DIFF
--- a/packages/agent-server-rust/src/router/status.rs
+++ b/packages/agent-server-rust/src/router/status.rs
@@ -24,9 +24,16 @@ use crate::tools::qr::{decode_qr_from_base64, to_data_url};
 use crate::tools::screenshot::capture_screenshot;
 
 pub async fn get_status() -> Json<serde_json::Value> {
+    let session = get_session("default");
+    let login_status = session
+        .as_ref()
+        .and_then(|s| s.logged_in_user.as_ref())
+        .map(|u| "logged_in".to_string())
+        .unwrap_or_else(|| "logged_out".to_string());
+
     Json(serde_json::json!({
         "container": "running",
-        "loginState": { "status": "logged_out" },
+        "loginState": { "status": login_status },
         "version": "0.1.0"
     }))
 }


### PR DESCRIPTION
## 问题
`/api/status` 始终返回 `logged_out`，即使微信已登录。导致消息发送失败。

## 原因
`get_status()` 函数硬编码返回 `logged_out`，没有读取数据库中实际的登录状态。

## 修复
`get_status()` 读取 `session.logged_in_user` 字段，与 `auth_status()` 保持一致。

## 测试
- `/api/status` → `logged_in` ✅
- `/api/status/auth` → 一致 ✅
- `/api/messages/send` → `{"success":true}` ✅

## 改动
- `packages/agent-server-rust/src/router/status.rs`: 8行修改

Fixes #110