### PR TITLE
fix(ci): skip npm self-install when runner ships compatible npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,20 @@ jobs:
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
-      # npm >= 11 required for OIDC trusted publishing
-      - run: npm install -g npm@11.12.1
+      # npm >= 11.5 required for OIDC trusted publishing. Skip the install when
+      # the runner image already ships a compatible npm, since self-install on
+      # Node 22.22.2's bundled npm fails with MODULE_NOT_FOUND: 'promise-retry'.
+      - name: Ensure npm >= 11.5 for OIDC trusted publishing
+        run: |
+          CURRENT=$(npm --version)
+          REQUIRED=11.5.0
+          if [ "$(printf '%s\n%s\n' "$REQUIRED" "$CURRENT" | sort -V | head -1)" = "$REQUIRED" ]; then
+            echo "npm $CURRENT is sufficient (>= $REQUIRED), skipping upgrade"
+          else
+            echo "Upgrading npm $CURRENT -> 11.12.1"
+            npm install -g npm@11.12.1
+          fi
+          echo "Active npm: $(npm --version)"
 
       - run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary
The release workflow's `npm install -g npm@11.12.1` step is failing on `ubuntu-latest` with Node 22.22.2:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
npm error Require stack:
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
```

The runner image already ships a compatible npm 11.x. The unconditional self-install triggers a broken rebuild inside the bundled npm.

This change keeps the same OIDC-trusted-publishing requirement (`npm >= 11.5`) but only runs the install when the active npm is actually older than that floor.

## Failing run
https://github.com/thisnick/agent-wechat/actions/runs/26003067698/job/76429717785

## Test plan
- [ ] Workflow re-runs successfully and `pnpm changeset publish` completes via OIDC
- [ ] Step output prints "npm <version> is sufficient" instead of running the install

🤖 Generated with [Claude Code](https://claude.com/claude-code)