### PR TITLE
fix(ci): activate npm 11.12.1 via Corepack instead of npm self-install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,19 +30,14 @@ jobs:
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
-      # npm >= 11.5 required for OIDC trusted publishing. Skip the install when
-      # the runner image already ships a compatible npm, since self-install on
-      # Node 22.22.2's bundled npm fails with MODULE_NOT_FOUND: 'promise-retry'.
-      - name: Ensure npm >= 11.5 for OIDC trusted publishing
+      # npm >= 11.5 required for OIDC trusted publishing. Use Corepack to
+      # activate it, because the bundled npm 10.9.7 in the Node 22.22.2 runner
+      # image is broken at the arborist rebuild step (MODULE_NOT_FOUND:
+      # 'promise-retry') and cannot install anything — including itself.
+      - name: Activate npm 11.12.1 via Corepack
         run: |
-          CURRENT=$(npm --version)
-          REQUIRED=11.5.0
-          if [ "$(printf '%s\n%s\n' "$REQUIRED" "$CURRENT" | sort -V | head -1)" = "$REQUIRED" ]; then
-            echo "npm $CURRENT is sufficient (>= $REQUIRED), skipping upgrade"
-          else
-            echo "Upgrading npm $CURRENT -> 11.12.1"
-            npm install -g npm@11.12.1
-          fi
+          corepack enable npm
+          corepack prepare npm@11.12.1 --activate
           echo "Active npm: $(npm --version)"
 
       - run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
The version-check fix in #163 didn't help: the runner image actually ships npm **10.9.7** (not 11.x), so the install path was still taken and hit the same `MODULE_NOT_FOUND: 'promise-retry'` failure.

The bundled npm 10.9.7 in the Node 22.22.2 toolcache image is broken at the arborist rebuild step — *any* `npm install` (including self-install) fails because every install ends in `reify-finish.js → arborist/rebuild.js → require('promise-retry')`, and that module is missing from the broken install.

We can't use the bundled npm to bootstrap a new npm. Switching to **Corepack** sidesteps the problem entirely: Corepack ships with Node, downloads package managers via its own mechanism, and doesn't go through the broken global npm.

## Failing run
https://github.com/thisnick/agent-wechat/actions/runs/26003240228

## Test plan
- [ ] Re-run release workflow; the step prints "Active npm: 11.12.1"
- [ ] `pnpm changeset publish` succeeds via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)